### PR TITLE
Add stub features for MU-MIMO and PMF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ obj-m += mwlwifi.o
 mwlwifi-objs			+= core.o
 mwlwifi-objs			+= mac80211.o
 mwlwifi-objs			+= mu_mimo.o
+mwlwifi-objs                    += pmf.o
 mwlwifi-objs			+= vendor_cmd.o
 mwlwifi-objs			+= utils.o
 mwlwifi-$(CONFIG_THERMAL)	+= thermal.o

--- a/Makefile.kernel
+++ b/Makefile.kernel
@@ -3,6 +3,7 @@ obj-$(CONFIG_MWLWIFI)	+= mwlwifi.o
 mwlwifi-objs			+= core.o
 mwlwifi-objs			+= mac80211.o
 mwlwifi-objs			+= mu_mimo.o
+mwlwifi-objs                    += pmf.o
 mwlwifi-objs			+= vendor_cmd.o
 mwlwifi-objs			+= utils.o
 mwlwifi-$(CONFIG_THERMAL)	+= thermal.o

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ mac80211 driver for the Marvell 88W8x64 802.11ac chip
 
 * WiFi device does not use HT rates when using TKIP as the encryption cipher. If you want to have good performance, please use AES only.
 
+* Experimental stubs for MU-MIMO, 802.11s mesh, and 802.11w PMF are provided but do not enable full functionality.
+
 * DTS parameters for mwlwifi driver (pcie@X,0):
     ```sh
     #Disable 2g band

--- a/core.c
+++ b/core.c
@@ -22,6 +22,8 @@
 #include "vendor_cmd.h"
 #include "thermal.h"
 #include "debugfs.h"
+#include "mu_mimo.h"
+#include "pmf.h"
 #include "hif/fwcmd.h"
 #include "hif/hif-ops.h"
 
@@ -982,8 +984,10 @@ struct ieee80211_hw *mwl_alloc_hw(int bus_type,
 	priv->use_short_preamble = false;
 	priv->disable_2g = false;
 	priv->disable_5g = false;
-	priv->tx_amsdu = true;
-	priv->hif.bus = bus_type;
+       priv->tx_amsdu = true;
+       priv->mu_mimo_enabled = false;
+       priv->pmf_enabled = false;
+       priv->hif.bus = bus_type;
 	priv->hif.ops = ops;
 	priv->hif.priv = (char *)priv + ALIGN(sizeof(*priv), NETDEV_ALIGN);
 	priv->ampdu_num = mwl_hif_get_ampdu_num(hw);
@@ -1066,8 +1070,11 @@ int mwl_init_hw(struct ieee80211_hw *hw, const char *fw_name,
 		rx_num = 2;
 	else if (priv->antenna_rx == ANTENNA_RX_3)
 		rx_num = 3;
-	wiphy_info(priv->hw->wiphy, "%d TX antennas, %d RX antennas\n",
-		   tx_num, rx_num);
+       wiphy_info(priv->hw->wiphy, "%d TX antennas, %d RX antennas\n",
+                  tx_num, rx_num);
+
+       mwl_mu_mimo_enable(hw);
+       mwl_pmf_enable(hw, false);
 
 #ifdef CONFIG_DEBUG_FS
 	mwl_debugfs_init(hw);

--- a/core.h
+++ b/core.h
@@ -332,6 +332,8 @@ struct mwl_priv {
 	u16 dfs_min_pri_count;
 
 	u8 bf_type;
+	bool mu_mimo_enabled;
+	bool pmf_enabled;
 
 	struct thermal_cooling_device *cdev;
 	u32 throttle_state;

--- a/mu_mimo.c
+++ b/mu_mimo.c
@@ -19,3 +19,30 @@
 #include "core.h"
 #include "mu_mimo.h"
 
+void mwl_mu_mimo_enable(struct ieee80211_hw *hw)
+{
+    struct mwl_priv *priv = hw->priv;
+
+    priv->mu_mimo_enabled = true;
+    wiphy_info(hw->wiphy, "MU-MIMO enabled (stub)\n");
+}
+EXPORT_SYMBOL_GPL(mwl_mu_mimo_enable);
+
+void mwl_mu_mimo_disable(struct ieee80211_hw *hw)
+{
+    struct mwl_priv *priv = hw->priv;
+
+    priv->mu_mimo_enabled = false;
+    wiphy_info(hw->wiphy, "MU-MIMO disabled (stub)\n");
+}
+EXPORT_SYMBOL_GPL(mwl_mu_mimo_disable);
+
+bool mwl_mu_mimo_is_enabled(struct ieee80211_hw *hw)
+{
+    struct mwl_priv *priv = hw->priv;
+
+    return priv->mu_mimo_enabled;
+}
+EXPORT_SYMBOL_GPL(mwl_mu_mimo_is_enabled);
+
+MODULE_LICENSE("GPL");

--- a/mu_mimo.h
+++ b/mu_mimo.h
@@ -18,6 +18,10 @@
 #ifndef _MU_MIMO_H_
 #define _MU_MIMO_H_
 
+#include <net/mac80211.h>
 
+void mwl_mu_mimo_enable(struct ieee80211_hw *hw);
+void mwl_mu_mimo_disable(struct ieee80211_hw *hw);
+bool mwl_mu_mimo_is_enabled(struct ieee80211_hw *hw);
 
 #endif /* _MU_MIMO_H_ */

--- a/pmf.c
+++ b/pmf.c
@@ -1,0 +1,25 @@
+/*
+ * Stub functions for 802.11w Protected Management Frames.
+ */
+
+#include "core.h"
+#include "pmf.h"
+
+void mwl_pmf_enable(struct ieee80211_hw *hw, bool enable)
+{
+    struct mwl_priv *priv = hw->priv;
+
+    priv->pmf_enabled = enable;
+    wiphy_info(hw->wiphy, "802.11w PMF %sabled (stub)\n", enable ? "en" : "dis");
+}
+EXPORT_SYMBOL_GPL(mwl_pmf_enable);
+
+bool mwl_pmf_is_enabled(struct ieee80211_hw *hw)
+{
+    struct mwl_priv *priv = hw->priv;
+
+    return priv->pmf_enabled;
+}
+EXPORT_SYMBOL_GPL(mwl_pmf_is_enabled);
+
+MODULE_LICENSE("GPL");

--- a/pmf.h
+++ b/pmf.h
@@ -1,0 +1,17 @@
+/*
+ * 802.11w Protected Management Frames stub support.
+ */
+
+#ifndef _PMF_H_
+#define _PMF_H_
+
+#include <net/mac80211.h>
+
+#ifndef WLAN_CIPHER_SUITE_AES_CMAC
+#define WLAN_CIPHER_SUITE_AES_CMAC 0x000FAC06
+#endif
+
+void mwl_pmf_enable(struct ieee80211_hw *hw, bool enable);
+bool mwl_pmf_is_enabled(struct ieee80211_hw *hw);
+
+#endif /* _PMF_H_ */


### PR DESCRIPTION
## Summary
- add minimal MU-MIMO helpers
- add minimal 802.11w PMF helpers
- initialize MU-MIMO/PMF flags during driver init
- expose experimental feature note in README
