### PR TITLE
Add override to relax MAC mask filtering

### DIFF
--- a/core.c
+++ b/core.c
@@ -30,6 +30,14 @@
 #define CMD_BUF_SIZE     0x4000
 #define INVALID_WATCHDOG 0xAA
 
+/* Optional override to disable strict MAC address masking. When enabled the
+ * driver attempts to accept frames from addresses outside the default mask.
+ */
+bool mwl_allow_any_mac;
+module_param_named(allow_any_mac, mwl_allow_any_mac, bool, 0644);
+MODULE_PARM_DESC(allow_any_mac,
+                "Attempt to accept frames from MAC addresses not sharing the firmware mask");
+
 static const struct ieee80211_channel mwl_channels_24[] = {
 	{ .band = NL80211_BAND_2GHZ, .center_freq = 2412, .hw_value = 1, },
 	{ .band = NL80211_BAND_2GHZ, .center_freq = 2417, .hw_value = 2, },
@@ -830,26 +838,30 @@ static int mwl_wl_init(struct mwl_priv *priv)
 		hw->wiphy->addresses =
 			kzalloc(addr_num * sizeof(*mac_addr), GFP_KERNEL);
 
-		mac_addr = &hw->wiphy->addresses[0];
-		ether_addr_copy(mac_addr->addr, priv->hw_data.mac_addr);
-		last_nibble = mac_addr->addr[5] & 0x0F;
-		for (addr_num = 0; addr_num < SYSADPT_NUM_OF_AP; addr_num++) {
-			mac_addr = &hw->wiphy->addresses[addr_num + 1];
-			ether_addr_copy(mac_addr->addr, priv->hw_data.mac_addr);
-			if (!strcmp(wiphy_name(hw->wiphy), "phy0")) {
-				last_nibble++;
-				if (last_nibble == 0x10)
-					last_nibble = 0;
-			} else {
-				last_nibble--;
-				if (last_nibble == 0xFF)
-					last_nibble = 0x0F;
-			}
-			mac_addr->addr[5] =
-				(mac_addr->addr[5] & 0xF0) | last_nibble;
-			mac_addr->addr[0] |= 0x2;
-		}
-	}
+               mac_addr = &hw->wiphy->addresses[0];
+               ether_addr_copy(mac_addr->addr, priv->hw_data.mac_addr);
+               last_nibble = mac_addr->addr[5] & 0x0F;
+               for (addr_num = 0; addr_num < SYSADPT_NUM_OF_AP; addr_num++) {
+                       mac_addr = &hw->wiphy->addresses[addr_num + 1];
+                       ether_addr_copy(mac_addr->addr, priv->hw_data.mac_addr);
+                       if (!mwl_allow_any_mac) {
+                               if (!strcmp(wiphy_name(hw->wiphy), "phy0")) {
+                                       last_nibble++;
+                                       if (last_nibble == 0x10)
+                                               last_nibble = 0;
+                               } else {
+                                       last_nibble--;
+                                       if (last_nibble == 0xFF)
+                                               last_nibble = 0x0F;
+                               }
+                               mac_addr->addr[5] =
+                                       (mac_addr->addr[5] & 0xF0) | last_nibble;
+                       } else {
+                               mac_addr->addr[5] += addr_num + 1;
+                       }
+                       mac_addr->addr[0] |= 0x2;
+               }
+       }
 
 	wiphy_info(hw->wiphy,
 		   "firmware version: 0x%x\n", priv->hw_data.fw_release_num);

--- a/core.h
+++ b/core.h
@@ -514,6 +514,12 @@ int mwl_init_hw(struct ieee80211_hw *hw, const char *fw_name,
 
 void mwl_deinit_hw(struct ieee80211_hw *hw);
 
+/* If true the driver will attempt to accept frames from MAC addresses not
+ * sharing the default mask with the primary address. Support depends on
+ * firmware capabilities.
+ */
+extern bool mwl_allow_any_mac;
+
 /* Defined in mac80211.c. */
 extern const struct ieee80211_ops mwl_mac80211_ops;
 

--- a/mac80211.c
+++ b/mac80211.c
@@ -492,14 +492,16 @@ static void mwl_mac80211_bss_info_changed(struct ieee80211_hw *hw,
 }
 
 static void mwl_mac80211_configure_filter(struct ieee80211_hw *hw,
-					  unsigned int changed_flags,
-					  unsigned int *total_flags,
-					  u64 multicast)
+                                          unsigned int changed_flags,
+                                          unsigned int *total_flags,
+                                          u64 multicast)
 {
-	/* AP firmware doesn't allow fine-grained control over
-	 * the receive filter.
-	 */
-	*total_flags &= FIF_ALLMULTI | FIF_BCN_PRBRESP_PROMISC;
+        /* AP firmware doesn't allow fine-grained control over
+         * the receive filter. When mwl_allow_any_mac is set we
+         * try to keep whatever flags mac80211 requests.
+         */
+        if (!mwl_allow_any_mac)
+                *total_flags &= FIF_ALLMULTI | FIF_BCN_PRBRESP_PROMISC;
 }
 
 static int mwl_mac80211_set_key(struct ieee80211_hw *hw,


### PR DESCRIPTION
## Summary
- add `allow_any_mac` module parameter for experimental promiscuous filtering
- make address initialization conditional on this flag
- relax `configure_filter` when the override is used

## Testing
- `make` *(fails: `make[1]: *** M=/workspace/mwlwifi: No such file or directory.  Stop.`)*

------
https://chatgpt.com/codex/tasks/task_e_684881b4c32c832c9974d6c4034ca108